### PR TITLE
Win header and footer updates

### DIFF
--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -121,116 +121,320 @@
   margin-bottom: 0.5rem;
 }
 
-/* Media query */
-@media (min-width: 611px) and (max-width: 768px) {
+/* ====== BASE STYLES: Mobile-first ====== */
+.footer-container {
+  padding: 2rem 1rem;
+  min-height: 400px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+  background-image: url("/bible.webp");
+  background-size: cover;
+  background-position: 60% center;
+  overflow: hidden;
+  color: #333;
+}
+
+.footer-container::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-color: rgba(255, 255, 255, 0.5);
+  z-index: 0;
+}
+
+.footer-container > * {
+  position: relative;
+  z-index: 1;
+  max-width: 100%;
+}
+
+.footer-top {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  text-align: center;
+}
+
+.footer-logo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 200px;
+}
+
+.logo {
+  max-width: 100%;
+  height: auto;
+  object-fit: contain;
+  filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.3));
+}
+
+.footerverse {
+  font-family: serif;
+  font-style: italic;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #3b3a30;
+  padding: 1rem;
+  text-align: center;
+  word-break: break-word;
+}
+
+.footer-partner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  margin: 1.5rem 0;
+}
+
+.partner-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.rightside-footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  margin-top: 2rem;
+  gap: 0.5rem;
+  overflow-wrap: break-word;
+}
+
+.footer-links {
+  display: flex;
+  gap: 1rem;
+  font-weight: 600;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.footer-links a {
+  color: #3b3a30;
+  text-decoration: none;
+  transition: color 0.3s ease;
+  white-space: nowrap;
+}
+
+.footer-links a:hover {
+  color: #555;
+}
+
+.footer-text {
+  font-size: 0.85rem;
+  color: #444;
+  max-width: 600px;
+  text-align: center;
+}
+/* ===== BASE STYLES (Mobile First) ===== */
+.footer-container {
+  padding: 2rem 1rem;
+  min-height: 400px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+  background-image: url("/bible.webp");
+  background-size: cover;
+  background-position: 60% center;
+  overflow: hidden;
+  color: #333;
+}
+
+.footer-container::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-color: rgba(255, 255, 255, 0.5);
+  z-index: 0;
+}
+
+.footer-container > * {
+  position: relative;
+  z-index: 1;
+  max-width: 100%;
+}
+
+.footer-top {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  text-align: center;
+}
+
+.footer-logo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 200px;
+}
+
+.logo {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  object-fit: contain;
+  filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.3));
+}
+
+.footerverse {
+  font-family: serif;
+  font-style: italic;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #3b3a30;
+  padding: 1rem;
+  word-break: break-word;
+  text-align: center;
+}
+
+.footer-partner {
+  font-family: sans-serif;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  margin: 1.5rem 0;
+  position: relative;
+  flex-wrap: wrap;
+  z-index: 1;
+}
+
+.partner-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.rightside-footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  margin-top: 2rem;
+  gap: 0.5rem;
+  overflow-wrap: break-word;
+}
+
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  font-weight: 600;
+}
+
+.footer-links a {
+  color: #3b3a30;
+  text-decoration: none;
+  transition: color 0.3s ease;
+  white-space: nowrap;
+}
+
+.footer-links a:hover {
+  color: #555;
+}
+
+.footer-text {
+  font-size: 0.9rem;
+  color: #444;
+  max-width: 600px;
+  text-align: center;
+  word-break: break-word;
+  margin-bottom: 0.5rem;
+}
+
+/* ===== 400px - 540px: Fix logo/cross overlap ===== */
+@media (min-width: 400px) and (max-width: 540px) {
+  .footer-logo {
+    padding-left: 2.5rem;
+  }
+
+  .footer-container {
+    background-position: 65% center;
+  }
+}
+
+/* ===== Tablets: 600px - 767px ===== */
+@media (min-width: 600px) and (max-width: 767px) {
   .footer-top {
     flex-direction: row;
+    align-items: flex-start;
     justify-content: space-between;
-    align-items: center;
-    gap: 2rem;
+    text-align: left;
   }
 
   .footer-logo {
-    flex: 0 0 200px;
+    align-items: flex-start;
+    padding-left: 6rem;
     max-width: 200px;
   }
 
   .footerverse {
-    flex: 1;
-    max-width: 100%;
-    text-align: left;
-    padding: 0;
-    margin-left: 2rem;
-  }
-}
-
-/* Optional: keep verse aligned left for medium screens */
-@media (min-width: 755px) {
-  .footerverse {
-    text-align: left;
-    margin-left: 2rem;
-    text-align: right;
+    text-align: center;
+    margin-left: 5rem;
     max-width: 300px;
-  }
-}
-/* Responsive tweaks */
-@media (max-width: 768px) {
-  .footer-top {
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
-    gap: 1rem;
-  }
-
-  .footer-logo,
-  .footerverse {
-    align-items: center;
-    text-align: center;
-    margin: 0 auto;
+    font-size: 1rem;
   }
 
   .rightside-footer {
-    align-items: center;
-    text-align: center;
-    margin-top: 2rem;
+    align-items: flex-end;
+    text-align: right;
   }
 
-  .footer-links {
-    justify-content: center;
-    flex-wrap: wrap;
-  }
-}
-
-/* Responsive tweaks */
-@media (max-width: 768px) {
-  .footer-top {
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
-    gap: 1rem;
-  }
-
-  .footer-logo,
-  .footerverse {
-    align-items: center;
-    text-align: center;
-    margin: 0 auto;
-  }
-
-  .rightside-footer {
-    align-items: center;
-    text-align: center;
-    margin-top: 2rem;
-  }
-
-  .footer-links {
-    justify-content: center;
-    flex-wrap: wrap;
-  }
-}
-
-/* === Desktop (1024px and above) === */
-@media (min-width: 1024px) {
   .footer-container {
-    padding: 1rem;
-    min-height: 500px;
+    background-position: 60% center;
+  }
+}
+
+/* ===== Desktop (768px and up) ===== */
+@media (min-width: 768px) {
+  .footer-container {
+    padding: 3rem;
+    background-position: 60% center;
   }
 
   .footer-logo {
     max-width: 200px;
+    padding-left: 0;
   }
 
   .footerverse {
-    font-size: 1.2rem;
-    max-width: 600px;
+    font-size: 1.15rem;
+    max-width: 500px;
   }
 
   .footer-links {
-    gap: 1.5rem;
+    gap: 1.2rem;
     font-size: 1rem;
   }
 
   .footer-text {
     font-size: 0.95rem;
+  }
+}
+
+/* ===== Large Desktops (1024px and up) ===== */
+@media (min-width: 1024px) {
+  .footer-container {
+    min-height: 500px;
+  }
+
+  .footerverse {
+    font-size: 1.2rem;
+  }
+
+  .footer-links {
+    gap: 1.5rem;
+  }
+
+  .footer-text {
+    font-size: 1rem;
   }
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -23,8 +23,8 @@ export default function Footer() {
 
         <div className="footer-verse-partner">
           <div className="footerverse">
-            “How beautiful are the feet of those who bring good news.” <br />
-            Romans 10:15
+            “How beautiful are the feet of those who bring good news.” Romans
+            10:15
           </div>
         </div>
       </div>

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -218,17 +218,17 @@
 /* ====== Media Query: 480px to 750px (Problem Range) ====== */
 @media (min-width: 480px) and (max-width: 750px) {
   .header-logo {
-    top: 2.5rem;
-    left: 1rem; /* Move logo away from center/cross */
-    max-width: 95px;
+    top: 2.7rem;
+    left: 0.95rem; /* Move logo away from center/cross */
+    max-width: 110px;
   }
 
   .header-verse {
     top: 60%; /* Lowered to avoid overlapping */
-    left: 65%; /* Pushed right, away from cross */
+    left: 60%; /* Pushed right, away from cross */
     transform: translate(-50%, -50%);
     font-size: 0.7rem;
-    max-width: 80%;
+    max-width: 70%;
   }
 
   .header-container {
@@ -240,21 +240,21 @@
 @media (min-width: 400px) and (max-width: 540px) {
   .header-logo {
     top: 2.8rem;
-    left: 8.5rem;
-    max-width: 100px;
+    left: 8rem;
+    max-width: 120px;
   }
 
   .header-verse {
-    top: 50%;
-    left: 50%;
+    top: 70%;
+    left: 40%;
     transform: translate(-50%, -50%);
-    font-size: 0.65rem;
+    font-size: 0.7rem;
     max-width: 70%;
     text-align: center;
   }
 
   .header-container {
-    background-position: 75% center;
+    background-position: 70% center;
   }
 }
 
@@ -290,8 +290,8 @@
 @media (min-width: 1024px) {
   .header-logo {
     top: 1.2rem;
-    left: 2.5rem;
-    max-width: 160px;
+    left: 2rem;
+    max-width: 180px;
   }
 
   .navbar {
@@ -302,7 +302,7 @@
   }
 
   .header-verse {
-    top: 50%;
+    top: 70%;
     left: 65%;
     font-size: 0.95rem;
     max-width: 450px;


### PR DESCRIPTION
Updates for a more professional, mobile-first responsive CSS structure.  What the updates solves:
Prevents the logo from overlapping the background cross between 400–767px.
Ensures a clean, consistent layout on all devices from mobile to desktop.
Applies padding and positioning selectively to .footer-logo and .footerverse.
Uses a mobile-first approach, scaling up styles progressively.